### PR TITLE
use more universal tail arguments and nc command name

### DIFF
--- a/internalblue/adbcore.py
+++ b/internalblue/adbcore.py
@@ -396,7 +396,7 @@ class ADBCore(InternalBlue):
             # automatically detect the proper serial device with lsof
             logfile = (
                 adb.process(
-                    ["su", "-c", "lsof | grep btsnoop_hci.log | tail -1 | awk '{print $NF}'"]
+                    ["su", "-c", "lsof | grep btsnoop_hci.log | tail -n 1 | awk '{print $NF}'"]
                 )
                 .recvall()
                 .strip()
@@ -424,8 +424,8 @@ class ADBCore(InternalBlue):
                 return False
 
             # spawn processes
-            adb.process(["su", "-c", "tail -f -n +0 %s | netcat -l -p 8872" % logfile])
-            adb.process(["su", "-c", "netcat -l -p 8873 >/sdcard/internalblue_input.bin"])
+            adb.process(["su", "-c", "tail -f -n +0 %s | nc -l -p 8872" % logfile])
+            adb.process(["su", "-c", "nc -l -p 8873 >/sdcard/internalblue_input.bin"])
             adb.process(
                 ["su", "-c", "tail -f /sdcard/internalblue_input.bin >>%s" % interface]
             )


### PR DESCRIPTION
Some older versions of busybox do not install nc as netcat and do not
support the tail -number syntax. This patch uses the more universal nc
command name and tail -n number syntax.

See #23