### PR TITLE
Added some build instructions

### DIFF
--- a/doc/ios.md
+++ b/doc/ios.md
@@ -20,8 +20,9 @@ There is a Settings App pane for `internalblued` to turn off the daemon and adap
 
 ## Building internalblued
 1. Install [theos](https://github.com/theos/theos)
-2. Run `make`
-3. A `.deb` file should be in the `packages` folder now
+2. Install the correct version of PrivateFramework header files (e.g. from [here](https://github.com/xybp888/iOS-SDKs)) for your build into your SDK
+3. Run `make`
+4. A `.deb` file should be in the `packages` folder now
 
 
 ## BlueTool

--- a/doc/ios.md
+++ b/doc/ios.md
@@ -21,7 +21,7 @@ There is a Settings App pane for `internalblued` to turn off the daemon and adap
 ## Building internalblued
 1. Install [theos](https://github.com/theos/theos)
 2. Install the correct version of PrivateFramework header files (e.g. from [here](https://github.com/xybp888/iOS-SDKs)) for your build into your SDK
-3. Run `make`
+3. Run `make package`
 4. A `.deb` file should be in the `packages` folder now
 
 


### PR DESCRIPTION
When you build from a clean Theos install, you will be missing the necessary headers for the build to succeed. I added the instruction to install the correct headers, as this took me over an hour to figure out..