### PR TITLE
Fixes the *use_ipython* error during launch

### DIFF
--- a/internalblue/cli.py
+++ b/internalblue/cli.py
@@ -169,7 +169,7 @@ class InternalBlueCLI(cmd2.Cmd):
             'leconnect': 'connectle', 'cle': 'connectle', 'lec': 'connectle',
             'sendh4': 'diag'})
 
-        super().__init__(shortcuts=shortcuts, persistent_history_file=data_directory + "/_internalblue.hist", use_ipython=True)
+        super().__init__(shortcuts=shortcuts, persistent_history_file=data_directory + "/_internalblue.hist", include_ipy=True)
 
         # Aliases have to be used instead of shortcuts
         # When the alias is equal with the beginning


### PR DESCRIPTION
The `use_ipython` parameter has been renamed to `include_ipy` since cmd2 v2.0.0.